### PR TITLE
generate_cert resource was not being checked

### DIFF
--- a/resources/listener_config.rb
+++ b/resources/listener_config.rb
@@ -48,7 +48,7 @@ alias :GenerateCert :generate_cert
 
 action :create do
   # If no certificate found and generateCert is true try to generate a self signed cert
-  if new_resource.listen_http && new_resource.thumbprint.nil? && load_thumbprint.empty?
+  if new_resource.generate_cert && new_resource.listen_https && new_resource.thumbprint.nil? && load_thumbprint.empty?
     Chef::Log.warn('Inside Create Cert')
     cookbook_file "#{Chef::Config[:file_cache_path]}\\selfssl.exe" do
       source 'selfssl.exe'


### PR DESCRIPTION
Corrected issue where create-cert was checking for listen_http instead of listen_https

## Description

generate_cert not being checked on create-cert.
listen_http used on create-cert instead of listen_https

### Issues Resolved

Correct issue where cookbook fails when run with:
generate_cert = false
listen_https = false

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
