### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- resolved cookstyle error: metadata.rb:13:1 refactor: `Chef/Modernize/DependsOnWindowsFirewallCookbook`
+- resolved cookstyle error: resources/listener_config.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 3.0.3 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,4 @@ source_url       'https://github.com/sous-chefs/winrm'
 issues_url       'https://github.com/sous-chefs/winrm/issues'
 chef_version     '>= 13.0'
 
-version          '3.0.3'
-
-depends          'windows_firewall', '>= 5.0' # >= chef 14.7
+version          '3.0.3' # >= chef 14.7

--- a/resources/listener_config.rb
+++ b/resources/listener_config.rb
@@ -21,6 +21,7 @@
 #
 
 provides :winrm_listener_config
+unified_mode true
 provides :winrm # legacy name
 
 property :hostname, String, default: lazy { node['fqdn'] }


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with metadata.rb

 - 13:1 refactor: `Chef/Modernize/DependsOnWindowsFirewallCookbook` - Don't depend on the windows_firewall cookbook made obsolete by Chef Infra Client 14.7. The windows_firewall resource is now included in Chef Infra Client itself. (https://docs.chef.io/workstation/cookstyle/chef_modernize_dependsonwindowsfirewallcookbook)

### Issues found and resolved with resources/listener_config.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)